### PR TITLE
Fix argument loading in r2asm.lua

### DIFF
--- a/r2asm.lua
+++ b/r2asm.lua
@@ -22,9 +22,13 @@ end
 local named_args = {}
 local unnamed_args = {}
 for ix, arg in ipairs({...}) do
-    local key, value = arg:match("^([^=]+)=(.-)$")
-    if key then
-        named_args[key] = value
+    if not (type(arg) == "number") then
+        local key, value = arg:match("^([^=]+)=(.-)$")
+        if key then
+            named_args[key] = value
+        else
+            table.insert(unnamed_args, arg)
+        end
     else
         table.insert(unnamed_args, arg)
     end


### PR DESCRIPTION
The previous version of r2asm would return "r2asm.lua:25: attempt to index local 'arg' (a number value)" when attempting to load a program
e.g. r2asm("quadratic.asm", 0xDEAD, "r2asm.dead.log")
This was because the argument loader would try to match numbers with regex. (in this case, the machine id: 0xDEAD)
This can be fixed by checking if the type of the argument, and if it's "number", then skipping the regex matching, and inserting the argument into the unnamed_args table